### PR TITLE
Make PollForSourceChanges configurable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -73,7 +73,7 @@ resource "aws_codepipeline" "bake_ami" {
       configuration {
         S3Bucket             = "${var.playbook_bucket}"
         S3ObjectKey          = "${var.playbook_key}"
-        PollForSourceChanges = "true"
+        PollForSourceChanges = "${var.codepipeline_poll_for_source_changes}"
       }
 
       run_order = "1"

--- a/variables.tf
+++ b/variables.tf
@@ -98,3 +98,9 @@ variable "lambda_function_name" {
   type        = "string"
   description = "The name of the AMI sharing lambda function"
 }
+
+variable "codepipeline_poll_for_source_changes" {
+  type        = "string"
+  description = "Whether or not the pipeline should poll for source changes"
+  default     = "true"
+}


### PR DESCRIPTION
To workaround the limit of 20 polling pipelines.

Already tested to create `aprafsa-ami-baking`.