### PR TITLE
add slack notification hook to codepipeline

### DIFF
--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -14,6 +14,7 @@ module "beitest_bake_ami" {
   template_instance_sg         = "template_instance_sg"
 
   service_name        = "beitest"
+  slack_channel       = "my_notification_channel"
   product_domain      = "bei"
   playbook_bucket     = "playbook_bucket"
   playbook_key        = "beitest/playbook.zip"

--- a/main.tf
+++ b/main.tf
@@ -112,7 +112,8 @@ resource "aws_codepipeline" "bake_ami" {
       version         = "1"
 
       configuration {
-        FunctionName = "${var.lambda_function_name}"
+        FunctionName   = "${var.lambda_function_name}"
+        UserParameters = "${format("{\"slack_channel\":\"%s\"}", var.slack_channel)}"
       }
 
       run_order = "1"

--- a/variables.tf
+++ b/variables.tf
@@ -104,3 +104,9 @@ variable "codepipeline_poll_for_source_changes" {
   description = "Whether or not the pipeline should poll for source changes"
   default     = "true"
 }
+
+variable "slack_channel" {
+  type        = "string"
+  default     = ""
+  description = "The name of the slack channel to which baked AMI IDs will be sent"
+}


### PR DESCRIPTION
developers can now set whether newly baked AMIs should be notified to a slack channel. The implementation itself depends on the lambda function, which is out of this module scope