### PR TITLE
fix sometimes codepipeline_poll_for_source_changes default to false

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -71,8 +71,9 @@ resource "aws_codepipeline" "bake_ami" {
       output_artifacts = ["Playbook"]
 
       configuration {
-        S3Bucket    = "${var.playbook_bucket}"
-        S3ObjectKey = "${var.playbook_key}"
+        S3Bucket             = "${var.playbook_bucket}"
+        PollForSourceChanges = "${var.codepipeline_poll_for_source_changes}"
+        S3ObjectKey          = "${var.playbook_key}"
       }
 
       run_order = "1"

--- a/variables.tf
+++ b/variables.tf
@@ -109,3 +109,9 @@ variable "slack_channel" {
   default     = ""
   description = "The name of the slack channel to which baked AMI IDs will be sent"
 }
+
+variable "codepipeline_poll_for_source_changes" {
+  type        = "string"
+  description = "Whether or not the pipeline should poll for source changes"
+  default     = "false"
+}


### PR DESCRIPTION
https://docs.aws.amazon.com/codepipeline/latest/userguide/reference-pipeline-structure.html#action-requirements said
```
¹In many cases, the PollForSourceChanges parameter defaults to true when you create a pipeline. When you add event-based change detection, you must add the parameter to your output and set it to false to disable polling. Otherwise, your pipeline starts twice for a single source change. For details, see Default Settings for the PollForSourceChanges Parameter.
```