### PR TITLE
Add playbook input artifcat in acdsami stage to allow custom inputs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -108,7 +108,7 @@ resource "aws_codepipeline" "bake_ami" {
       category        = "Invoke"
       owner           = "AWS"
       provider        = "Lambda"
-      input_artifacts = ["PackerManifest"]
+      input_artifacts = ["PackerManifest", "Playbook"]
       version         = "1"
 
       configuration {


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->
Allow acdsami to access Playbook artifact for additional file inputs (such as commit id/branch name) on lambda notification

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Add Playbook input artifact to acdsami

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-bake-ami/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

* Any Notes regarding your submitted PR, like breaking changes or else.

FEATURES:

Add Playbook input artifact to acdsami

