### PR TITLE
add-encryption-key-as-input 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,17 +14,16 @@ resource "aws_cloudwatch_log_group" "bake_ami" {
 }
 
 resource "aws_codebuild_project" "bake_ami" {
-  name         = "${local.bake_project_name}"
-  description  = "Bake ${var.service_name} AMI"
-  service_role = "${var.codebuild_role_arn}"
+  name           = "${local.bake_project_name}"
+  description    = "Bake ${var.service_name} AMI"
+  service_role   = "${var.codebuild_role_arn}"
+  encryption_key = "${var.codepipeline_artifact_bucket_encryption_key_arn}"
 
   artifacts {
     type           = "CODEPIPELINE"
     namespace_type = "BUILD_ID"
     packaging      = "ZIP"
   }
-
-  encryption_key = ""
 
   cache {
     type     = "${var.codebuild_cache_bucket == "" ? "NO_CACHE" : "S3"}"

--- a/main.tf
+++ b/main.tf
@@ -24,16 +24,18 @@ resource "aws_codebuild_project" "bake_ami" {
     packaging      = "ZIP"
   }
 
+  encryption_key = ""
+
   cache {
     type     = "${var.codebuild_cache_bucket == "" ? "NO_CACHE" : "S3"}"
     location = "${var.codebuild_cache_bucket}/${local.bake_project_name}"
   }
 
   environment {
-    compute_type = "${var.bake_codebuild_compute_type}"
-    image        = "${var.bake_codebuild_image}"
+    compute_type                = "${var.bake_codebuild_compute_type}"
+    image                       = "${var.bake_codebuild_image}"
     image_pull_credentials_type = "${var.bake_codebuild_image_credentials}"
-    type         = "${var.bake_codebuild_environment_type}"
+    type                        = "${var.bake_codebuild_environment_type}"
   }
 
   source {
@@ -120,6 +122,7 @@ resource "aws_codepipeline" "bake_ami" {
       run_order = "1"
     }
   }
+
   tags {
     "Name"          = "${local.pipeline_name}"
     "Description"   = "${var.service_name} AMI Baking Pipeline"

--- a/variables.tf
+++ b/variables.tf
@@ -72,6 +72,11 @@ variable "codepipeline_artifact_bucket" {
   description = "An S3 bucket to be used as CodePipeline's artifact bucket"
 }
 
+variable "codepipeline_artifact_bucket_encryption_key_arn" {
+  type        = "string"
+  description = "The AWS Key Management Service (AWS KMS) customer master key (CMK) to be used for encrypting the build output artifacts."
+}
+
 variable "codebuild_cache_bucket" {
   type        = "string"
   description = "An S3 bucket to be used as CodeBuild's cache bucket"


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
add variable to explicitly define s3 bucket encryption key in use for build artifact

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-bake-ami/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

* Require one additional variable to be inputted **codepipeline_artifact_bucket_encryption_key_arn**

FEATURES:

* Explicitly defined key in use for encrypting codebuild artifact

ENHANCEMENTS:

* -

BUG FIXES:

* -
```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
