### PR TITLE
Add option to remove cloudwatch trigger

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -131,6 +131,7 @@ resource "aws_codepipeline" "bake_ami" {
 }
 
 resource "aws_cloudwatch_event_rule" "this" {
+  count       = "${var.codepipeline_s3_upload_cloudwatch_trigger == true ? 1 : 0}"
   name        = "${local.pipeline_name}-trigger"
   description = "Capture each s3://${var.playbook_bucket}/${var.playbook_key} upload"
 
@@ -161,8 +162,9 @@ PATTERN
 }
 
 resource "aws_cloudwatch_event_target" "this" {
-  rule = "${aws_cloudwatch_event_rule.this.name}"
-  arn  = "${aws_codepipeline.bake_ami.arn}"
+  count = "${var.codepipeline_s3_upload_cloudwatch_trigger == true ? 1 : 0}"
+  rule  = "${aws_cloudwatch_event_rule.this.name}"
+  arn   = "${aws_codepipeline.bake_ami.arn}"
 
   role_arn = "${var.events_role_arn}"
 }

--- a/main.tf
+++ b/main.tf
@@ -30,10 +30,10 @@ resource "aws_codebuild_project" "bake_ami" {
   }
 
   environment {
-    compute_type = "${var.bake_codebuild_compute_type}"
-    image        = "${var.bake_codebuild_image}"
+    compute_type                = "${var.bake_codebuild_compute_type}"
+    image                       = "${var.bake_codebuild_image}"
     image_pull_credentials_type = "${var.bake_codebuild_image_credentials}"
-    type         = "${var.bake_codebuild_environment_type}"
+    type                        = "${var.bake_codebuild_environment_type}"
   }
 
   source {
@@ -120,6 +120,7 @@ resource "aws_codepipeline" "bake_ami" {
       run_order = "1"
     }
   }
+
   tags {
     "Name"          = "${local.pipeline_name}"
     "Description"   = "${var.service_name} AMI Baking Pipeline"

--- a/main.tf
+++ b/main.tf
@@ -131,7 +131,7 @@ resource "aws_codepipeline" "bake_ami" {
 }
 
 resource "aws_cloudwatch_event_rule" "this" {
-  count       = "${var.codepipeline_s3_upload_cloudwatch_trigger == true ? 1 : 0}"
+  count       = "${var.codepipeline_s3_upload_cloudwatch_trigger == "true" ? 1 : 0}"
   name        = "${local.pipeline_name}-trigger"
   description = "Capture each s3://${var.playbook_bucket}/${var.playbook_key} upload"
 
@@ -162,7 +162,7 @@ PATTERN
 }
 
 resource "aws_cloudwatch_event_target" "this" {
-  count = "${var.codepipeline_s3_upload_cloudwatch_trigger == true ? 1 : 0}"
+  count = "${var.codepipeline_s3_upload_cloudwatch_trigger == "true" ? 1 : 0}"
   rule  = "${aws_cloudwatch_event_rule.this.name}"
   arn   = "${aws_codepipeline.bake_ami.arn}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -123,6 +123,7 @@ variable "codepipeline_poll_for_source_changes" {
 }
 
 variable "codepipeline_s3_upload_cloudwatch_trigger" {
+  type        = "string"
   description = "Create a s3 upload pipeline cloudwatch trigger or not"
   default     = "true"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -124,5 +124,5 @@ variable "codepipeline_poll_for_source_changes" {
 
 variable "codepipeline_s3_upload_cloudwatch_trigger" {
   description = "Create a s3 upload pipeline cloudwatch trigger or not"
-  default     = true
+  default     = "true"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -121,3 +121,8 @@ variable "codepipeline_poll_for_source_changes" {
   description = "Whether or not the pipeline should poll for source changes"
   default     = "false"
 }
+
+variable "codepipeline_s3_upload_cloudwatch_trigger" {
+  description = "Create a s3 upload pipeline cloudwatch trigger or not"
+  default     = true
+}


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Add option based on #36 

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-bake-ami/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

* Backward compatibility checked

ENHANCEMENT:

* New variable to make s3 upload cloudwatch trigger optional
```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
